### PR TITLE
Updated Docker Container and made MockOresat fancier

### DIFF
--- a/cosmos/docker/Dockerfile
+++ b/cosmos/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
 
+# Import all the build arguments and environment variables
 ENV TIMEZONE America/Los_Angeles
 ENV COSMOS_REPO https://github.com/oresat/uniclogs-software
 ENV COSMOS_BRANCH cosmos
@@ -10,10 +11,12 @@ ARG DART_DB
 ARG DART_USERNAME
 ARG DART_PASSWORD
 
+# Set the timezone, do a system update, then save the timezone config
 RUN ln -fs /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
 RUN apt-get update && apt-get install -y tzdata
 RUN dpkg-reconfigure --frontend noninteractive tzdata
 
+# Install Ubuntu-based dependencies
 RUN apt-get install -qqy \
   cmake \
   curl \
@@ -48,9 +51,12 @@ RUN apt-get install -qqy \
   x11-apps \
   zlib1g-dev
 
+# Install Rake and Bundler
 RUN gem install rake --no-document
 RUN gem install bundle --no-document
 
+# Pull down the repo and switch to the designated branch (non-master)
+#   Then extract the COSMOS configs and remove everything else
 RUN git clone ${COSMOS_REPO} /opt/
 WORKDIR /opt
 RUN git checkout ${COSMOS_BRANCH}
@@ -58,5 +64,10 @@ RUN mv /opt/cosmos /
 RUN rm -rf /opt/*
 RUN mv /cosmos /opt
 WORKDIR /opt/cosmos
+
+# Install COSMOS dependencies and copy the DB populate script into the container
 RUN bundle install
-CMD ruby tools/Dart && ruby tools/CmdTlmServer --no-gui
+COPY ./start.sh ./start.sh
+
+# Entry services
+CMD bash /opt/cosmos/start.sh

--- a/cosmos/docker/Makefile
+++ b/cosmos/docker/Makefile
@@ -9,6 +9,7 @@ USE_LOCAL_BUILD=1
 START_INTERACTIVE_MODE=0
 
 build:
+	$(info Using Arguments: ($(DART_DB), $(DART_USERNAME), $(DART_PASSWORD), $(LOCAL_IMAGE)))
 	docker build --compress --network=host --build-arg DART_DB=$(DART_DB) --build-arg DART_USERNAME=$(DART_USERNAME) --build-arg DART_PASSWORD=$(DART_PASSWORD) --force-rm --tag $(LOCAL_IMAGE) .
 
 run:

--- a/cosmos/docker/start.sh
+++ b/cosmos/docker/start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+function action() {
+  echo -e "\n\n---\nSTARTING ACTION: : $1\n---\n"
+  $1
+}
+
+action "bundle exec rake db:schema:load" && action "bundle exec rake db:seed" &
+action "ruby tools/Dart" &
+action "ruby tools/CmdTlmServer --no-gui" &
+
+echo -e "Finished starting all of the services!"
+
+echo -e "Will spin forever now..."
+
+while [[ 1 ]]; do
+  echo -e "[$(date)]: Spinning..."
+  sleep 1
+done

--- a/cosmos/mocks/oresat.py
+++ b/cosmos/mocks/oresat.py
@@ -1,45 +1,147 @@
 #!/usr/bin/env python3
 import sys
+import enum
+import time
 import socket
+import argparse
+import threading
 
 
-def receive_packet(connection):
-    cmd_data = connection.recv(256)
-    if not cmd_data:
-        raise Exception("Connection closed")
+class Mode(enum.Enum):
+    info = 0
+    warn = 1
+    error = 2
+    debug = 3
 
-    print(cmd_data)  # pktid is the first 16 bytes
-    pktid = cmd_data[:16]
-    if pktid == 10:
-        print("received PASS_SCHEDULE command")
-    elif pktid == 20:
-        print("received PASS_CANCEL command")
-    else:
-        e = "WHOA unexcepted pktid {} for command {}".format(pktid, cmd_data)
-        raise Exception(e)
-    return pktid
+    def __repr__(self):
+        return self.name.upper()
+
+
+class MockOresat(threading.Thread):
+    """
+    Operates as a killable helper-thread for accepting connections from COSMOS
+    """
+
+    def __init__(self,
+                 screen_lock: threading.Lock,
+                 connection: socket.socket,
+                 client: tuple,
+                 *kwargs):
+        super().__init__(target=self.event_loop)
+        self.screen_lock = screen_lock
+        self.connection = connection
+        self.client = client
+        self.setDaemon(True)
+        self.name = 'Oresat Connection Listener{}'.format(self.client)
+        self.alive = True
+
+    def safe_print(self, msg: str, mode: Mode = Mode.info) -> None:
+        thread_id = threading.get_ident()
+        self.screen_lock.acquire()
+        print('({})[{}][{}]: {}'.format(thread_id,
+                                        time.ctime(),
+                                        mode,
+                                        msg))
+        self.screen_lock.release()
+
+    def extract_packet(self) -> int:
+        cmd_data = self.connection.recv(256)
+        if not cmd_data:
+            raise Exception("Connection closed")
+
+        print(cmd_data)  # pktid is the first 16 bytes
+        pktid = cmd_data[:16]
+        if pktid == 10:
+            print("Received PASS_SCHEDULE command")
+        elif pktid == 20:
+            print("Received PASS_CANCEL command")
+        else:
+            e = "WHOA unexcepted pktid {} for command {}" \
+                .format(pktid, cmd_data)
+            raise Exception(e)
+        return pktid
+
+    def event_loop(self):
+        self.safe_print('Accepted a new connection from {}'
+                        .format(self.client))
+        try:
+            while self.alive:
+                packet_id = self.extract_packet()
+                self.safe_print('Recieved packet with id: {}'
+                                .format(packet_id))
+        except (KeyboardInterrupt, SystemExit):
+            self.safe_print('Connection closed by server!')
+        except Exception:
+            self.safe_print('Connection closed by client!')
+        finally:
+            self.stop()
+
+    def stop(self):
+        if(not self.alive):
+            self.connection.shutdown(socket.SHUT_RDWR)
+            self.connection.close()
+        else:
+            self.safe_print('Listner with pid: {} was already closed!'
+                            .format(self.ident))
+        self.alive = False
+
+    def __repr__(self):
+        return '<MockOresat ({}) {} ({})>'.format(self.ident,
+                                                  self.client,
+                                                  self.connection)
 
 
 def main(args):
+    parser = argparse.ArgumentParser(prog='oresat',
+                                     description='A mock of Oresat.',
+                                     allow_abbrev=False)
+    parser.add_argument('-H', '--host',
+                        dest='host',
+                        type=str,
+                        nargs=1,
+                        default='localhost',
+                        help='[Default: localhost] Host for Mock Oresat to bind to.')
+    parser.add_argument('-P', '--port',
+                        dest='port',
+                        type=int,
+                        nargs=1,
+                        default=8888,
+                        help='[Default: 8888]: Port for Mock Oresat to bind to.')
+    parser.add_argument('-m', '--max-connections',
+                        dest='max_connections',
+                        type=int,
+                        nargs=1,
+                        help='Maximum number of connections to accept.')
+    args = parser.parse_args(args)
+    screen_lock = threading.Lock()
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server_address = ('localhost', 8888)
-    sock.bind(server_address)
+    sock.bind((args.host, args.port))
     sock.listen(1)
 
-    print('waiting for a connection on %s port %s' % server_address)
-    connection, client_address = sock.accept()
+    print('Opended OreSat Mock at {}:{}'.format(args.host,
+                                                args.port))
+    connections = []
 
-    try:
-        print('connection from', client_address)
-        while True:
-            pktid = receive_packet(connection)
-            print('packet id: {}'.format(pktid))
-    except KeyboardInterrupt:
-        print('Goodbye')
-    finally:
-        print('shutting down socket')
-        connection.shutdown(socket.SHUT_RDWR)
-        connection.close()
+    while True:
+        try:
+            connection, client = sock.accept()
+            thread_count = len(threading.enumerate()) - 1
+
+            if(args.max_connections is not None
+                and thread_count >= args.max_connections[0]):
+                print('Max connection limit reached! Throwing out connection!')
+                connection.shutdown(socket.SHUT_RDWR)
+                connection.close()
+            else:
+                new_connection = MockOresat(screen_lock, connection, client)
+                connections.append(new_connection)
+                new_connection.run()
+        except (KeyboardInterrupt, SystemExit):
+            for connection in connections:
+                print('Closing connection: {}'.format(connection))
+                connection.stop()
+            sock.shutdown(socket.SHUT_RDWR)
+            sys.exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Added `start.sh` script that runs multiple services on container boot
* Added the rake install scripts such that the docker image now tries to populate the DB with DART's tables on boot.
* Made MockOrsat capable of:
  * Handling multiple connections
  * Allowing dropped connections by the client
  * Allowing dropped connections by the server

*(Will also eventually make MockOresat capable of sending messages to COSMOS indicating canceled requests on the satellite's behalf)*